### PR TITLE
Support DMS (Disk Masher Sytem) disks

### DIFF
--- a/js/vc64_ui.js
+++ b/js/vc64_ui.js
@@ -745,7 +745,7 @@ function configure_file_dialog(reset=false)
             $("#auto_press_play").prop('checked', auto_press_play);
             $("#auto_run").prop('checked', auto_run);    
 
-            if(file_slot_file_name.match(/[.](prg|t64|crt|adf)$/i))
+            if(file_slot_file_name.match(/[.](prg|t64|crt|adf|dms)$/i))
             {
                 insert_file();
             }

--- a/shell.html
+++ b/shell.html
@@ -152,7 +152,7 @@
         </svg>
       </button>
       <form id="theFileInput" style="display: inline-block;">
-        <div id="drop_zone" class="px-1 u-full-width mr-1" data-toggle="tooltip" data-placement="bottom" title="drop .adf or .zip files into here, or just click into the drop zone">
+        <div id="drop_zone" class="px-1 u-full-width mr-1" data-toggle="tooltip" data-placement="bottom" title="drop .adf, .dms or .zip files into here, or just click into the drop zone">
           file slot
         </div>
         <!-- iOS won't work with accept=".g64,.d64,.crt,.prg,.bin" on d64 files -->


### PR DESCRIPTION
Hi,

My first attempt at a pull request, so please be extra brutal :) (Especially concerning the html/js changes, I'm mostly just guessing there).

This should add support for [DMS](https://en.wikipedia.org/wiki/Disk_Masher_System) disk files. They're already support by vAmiga and are quite common format for older stuff. As an example the download link for [Spaceballs - State of the art](https://www.pouet.net/prod.php?which=99). 