### PR TITLE
Moira: Added instruction cache and latch flushing on state changes

### DIFF
--- a/Core/Components/CPU/CPU.cpp
+++ b/Core/Components/CPU/CPU.cpp
@@ -675,6 +675,14 @@ CPU::_didLoad()
     // Rectify the CPU type
     setModel(cpuModel, dasmModel);
 
+    /* Because the contents of the instruction cache are not part of a snapshot,
+     * stale cache lines from the previously executed program may survive the
+     * restore operation. To prevent the CPU from fetching such lines, the cache
+     * is flushed. Note that setModel() flushes the cache only if the CPU model
+     * has changed, which is usually not the case here.
+     */
+    flushInstructionCache();
+
     /* Because we don't save breakpoints and watchpoints in a snapshot, the
      * CPU flags for checking breakpoints and watchpoints can be in a corrupt
      * state after loading. These flags need to be updated according to the

--- a/Core/Components/CPU/CPU.h
+++ b/Core/Components/CPU/CPU.h
@@ -118,6 +118,9 @@ public:
                      (moira::Model)other.config.dasmRevision);
         }
 
+        // The instruction cache is not cloned. Drop stale lines.
+        flushInstructionCache();
+
         return *this;
     }
 

--- a/Core/Components/CPU/Moira/Moira.cpp
+++ b/Core/Components/CPU/Moira/Moira.cpp
@@ -518,7 +518,7 @@ void
 Moira::setCACR(u32 val)
 {
     reg.cacr = val & cacrMask();
-    if (is68020()) flushInstructionCache();
+    if (hasICache()) flushInstructionCache();
     didChangeCACR(val);
 }
 
@@ -532,11 +532,17 @@ Moira::setCAAR(u32 val)
 void
 Moira::flushInstructionCache()
 {
-    iCacheAddr020 = 0xffffffff;
-    iCacheData020 = 0xffffffff;
+    flushInstructionLatch();
     for (int i = 0; i < ICacheLines020; i++) {
         iCache020[i].valid = false;
     }
+}
+
+void
+Moira::flushInstructionLatch()
+{
+    iCacheAddr020 = 0xffffffff;
+    iCacheData020 = 0xffffffff;
 }
 
 void

--- a/Core/Components/CPU/Moira/Moira.h
+++ b/Core/Components/CPU/Moira/Moira.h
@@ -54,6 +54,12 @@ public:
     // Checks whether the emulated CPU is a 68020 (EC or full)
     bool is68020() const { return cpuModel == Model::M68EC020 || cpuModel == Model::M68020; }
     
+    /* Checks whether the emulated CPU has an instruction cache. The condition
+     * matches the models that fetch through readInstructionCache(), i.e. all
+     * models emulated by the 68020 core.
+     */
+    bool hasICache() const { return cpuModel > Model::M68010; }
+    
     // Debugger handling breakpoints, watchpoints, catchpoints, and instruction tracing
     Debugger debugger = Debugger(*this);
     
@@ -486,6 +492,7 @@ protected:
 
     // 68020 instruction cache helpers
     void flushInstructionCache();
+    void flushInstructionLatch();
     void fillInstructionCache(u32 addr);
     u16 readInstructionCache(u32 addr);
 

--- a/Core/Components/CPU/Moira/MoiraDataflow_cpp.h
+++ b/Core/Components/CPU/Moira/MoiraDataflow_cpp.h
@@ -662,6 +662,15 @@ Moira::fullPrefetch()
 {
     assert(!misaligned<C>(reg.pc));
 
+    /* This function is called whenever the instruction pipe is refilled, i.e.
+     * on all changes of the control flow. Because the longword latch models the
+     * data in flight, it has to be invalidated here. Otherwise, the CPU would
+     * keep seeing stale opcode words even with the instruction cache switched
+     * off. Cached lines are not affected. Just as on the real machine, they
+     * remain valid until the cache is flushed via CACR.
+     */
+    flushInstructionLatch();
+
     queue.irc = readInstructionWord<C>(reg.pc);
     if (delay) SYNC(delay);
     prefetch<C, F>();
@@ -752,6 +761,7 @@ Moira::jumpToVector(int nr)
     }
 
     // Update the prefetch queue
+    flushInstructionLatch();
     queue.irc = (u16)read<C, AddrSpace::PROG, Word>(reg.pc);
     SYNC(2);
     prefetch<C, POLL>();


### PR DESCRIPTION
Flush instruction cache when loading snapshots or cloning CPU state to prevent stale cache lines from previous programs. Flush instruction latch (iCacheAddr020/iCacheData020) on control flow changes in fullPrefetch() and jumpToVector() to prevent stale opcode words when cache is disabled. Added hasICache() helper to check for instruction cache support. Updated setCACR() to use hasICache() instead of is68020().